### PR TITLE
feat: Recreate project views in Flutter

### DIFF
--- a/flutter-ui-boilerplate/lib/main.dart
+++ b/flutter-ui-boilerplate/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:boilerplate_ui/views/app_screen.dart';
+import 'package:boilerplate_ui/views/recreated/recreated_home_page.dart'; // Import the new home page
 import 'package:boilerplate_ui/utils/size_config.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -51,6 +51,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     MySize().init(context);
     themeData = Theme.of(context);
-    return AppScreen();
+    // Return the new RecreatedHomePage instead of AppScreen
+    return RecreatedHomePage();
   }
 }

--- a/flutter-ui-boilerplate/lib/views/recreated/recreated_home_page.dart
+++ b/flutter-ui-boilerplate/lib/views/recreated/recreated_home_page.dart
@@ -1,0 +1,522 @@
+import 'package:boilerplate_ui/utils/size_config.dart';
+import 'package:boilerplate_ui/widgets/recreated_header.dart';
+import 'package:flutter/material.dart';
+import 'package:lucide_flutter/lucide_flutter.dart';
+import 'recreated_auth_page.dart';
+import 'recreated_client_dashboard_page.dart';
+import 'recreated_worker_dashboard_page.dart';
+import 'recreated_subscriptions_page.dart'; // Import Subscriptions Page
+
+class RecreatedHomePage extends StatelessWidget {
+  const RecreatedHomePage({Key key}) : super(key: key);
+
+  // Data similar to HomePage.tsx (omitted for brevity, assume it's the same as before)
+  final List<Map<String, dynamic>> features = const [
+    {
+      "icon": LucideIcons.shield,
+      "title": 'Trabajadores Verificados',
+      "description": 'Todos nuestros trabajadores pasan por verificación de identidad y antecedentes'
+    },
+    {
+      "icon": LucideIcons.star,
+      "title": 'Calificaciones Reales',
+      "description": 'Sistema de calificaciones transparente basado en experiencias reales'
+    },
+    {
+      "icon": LucideIcons.checkCircle,
+      "title": 'Garantía de Servicio',
+      "description": 'Si no estás satisfecho, te ayudamos a solucionarlo o te devolvemos tu dinero'
+    }
+  ];
+
+  final List<Map<String, dynamic>> categories = const [
+    {"name": 'Plomería', "icon": LucideIcons.wrench, "color": Color(0xFFE0F2FE), "textColor": Color(0xFF0C4A6E)},
+    {"name": 'Electricidad', "icon": LucideIcons.zap, "color": Color(0xFFFEF9C3), "textColor": Color(0xFF713F12)},
+    {"name": 'Pintura', "icon": LucideIcons.palette, "color": Color(0xFFF3E8FF), "textColor": Color(0xFF581C87)},
+    {"name": 'Jardinería', "icon": LucideIcons.flower2, "color": Color(0xFFDCFCE7), "textColor": Color(0xFF166534)},
+    {"name": 'Limpieza', "icon": LucideIcons.sparkles, "color": Color(0xFFFCE7F3), "textColor": Color(0xFF831843)},
+    {"name": 'Carpintería', "icon": LucideIcons.hammer, "color": Color(0xFFFFF7ED), "textColor": Color(0xFF7C2D12)},
+    {"name": 'Reparaciones', "icon": LucideIcons.settings, "color": Color(0xFFF3F4F6), "textColor": Color(0xFF374151)},
+    {"name": 'Mudanza', "icon": LucideIcons.truck, "color": Color(0xFFE0E7FF), "textColor": Color(0xFF3730A3)},
+  ];
+
+  final List<Map<String, String>> stats = const [
+    {"number": '10,000+', "label": 'Servicios Completados'},
+    {"number": '2,500+', "label": 'Trabajadores Verificados'},
+    {"number": '4.8/5', "label": 'Calificación Promedio'},
+    {"number": '24h', "label": 'Tiempo de Respuesta'}
+  ];
+
+
+  // Navigation Handler
+  void _handleNavigation(BuildContext context, String pageKey) {
+    print("HomePage received navigation request for: $pageKey");
+    Widget targetPage;
+
+    switch (pageKey) {
+      case 'auth_login':
+        targetPage = RecreatedAuthPage(initialMode: 'login');
+        break;
+      case 'auth_register':
+        targetPage = RecreatedAuthPage(initialMode: 'register');
+        break;
+      case 'client_dashboard':
+        targetPage = RecreatedClientDashboardPage();
+        break;
+      case 'worker_dashboard':
+        targetPage = RecreatedWorkerDashboardPage();
+        break;
+      case 'subscriptions_page':
+        targetPage = RecreatedSubscriptionsPage();
+        break;
+      case 'home':
+        print("Already on home or main page. Optionally pop if not root.");
+        if (ModalRoute.of(context)?.settings.name != '/') {
+          // Consider Navigator.popUntil(context, ModalRoute.withName('/'));
+          // or ensure HomePage is always at the root or use a more robust navigation system.
+        }
+        return; // Don't push if already home or handled
+      case 'logout':
+        print("Logout requested. (Demo: Navigating to home, no actual state change)");
+        // In a real app: clear auth state, then navigate.
+        // For this demo, if we navigate to 'home', the RecreatedHeader
+        // might not change its appearance unless `isDemoAuthenticated` is also changed
+        // through some (currently non-existent) state management that RecreatedHomePage listens to.
+        // For now, we can just pop all routes and push home, or rely on RecreatedHeader's current logic.
+        // Navigator.of(context).popUntil((route) => route.isFirst);
+        // Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => RecreatedHomePage()));
+        // For simplicity, let's just print and not change the UI state for logout in this pass.
+        return;
+      default:
+        print("Unknown navigation key: $pageKey");
+        return;
+    }
+
+    if (targetPage != null) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (context) => targetPage),
+      );
+    }
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    MySize().init(context);
+
+    // For demo purposes, let's assume we want to show the "authenticated" header state on HomePage
+    // to easily access the "Panel Principal" button.
+    // In a real app, this would be driven by actual authentication state.
+    bool isDemoAuthenticated = true;
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: RecreatedHeader(
+        currentPage: 'home',
+        isAuthenticated: isDemoAuthenticated, // Using demo authenticated state
+        onNavigate: (pageKey) => _handleNavigation(context, pageKey),
+      ),
+      endDrawer: RecreatedMobileDrawer(
+        // Pass isAuthenticated to drawer if it needs to conditionally show items
+        // For now, its internal logic for showing auth items is based on onNavigate != null
+        onNavigate: (pageKey) => _handleNavigation(context, pageKey),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildHeroSection(context),
+            _buildStatsSection(context),
+            _buildCategoriesSection(context),
+            _buildFeaturesSection(context),
+            _buildCtaSection(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ... (rest of the _build<SectionName> methods remain the same as before) ...
+  // Omitting them here for brevity as they don't change for this step.
+  // Assume they are identical to the previous version of RecreatedHomePage.
+
+  Widget _buildHeroSection(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(
+          horizontal: MySize.size16, vertical: MySize.size64),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [Colors.blue[700], Colors.blue[800], Colors.blue[900]],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+      ),
+      child: LayoutBuilder(builder: (context, constraints) {
+        bool isLargeScreen = constraints.maxWidth > 768;
+        return Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    "Conectamos servicios con",
+                    style: TextStyle(
+                        fontSize: MySize.getScaledSize(isLargeScreen ? 48 : 36),
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                        height: 1.2),
+                  ),
+                  Text(
+                    "confianza",
+                    style: TextStyle(
+                        fontSize: MySize.getScaledSize(isLargeScreen ? 48 : 36),
+                        fontWeight: FontWeight.bold,
+                        color: Colors.blue[300],
+                        height: 1.2),
+                  ),
+                  SizedBox(height: MySize.size24),
+                  Text(
+                    "La plataforma líder en Perú para encontrar trabajadores verificados para tus necesidades del hogar y negocio.",
+                    style: TextStyle(
+                        fontSize: MySize.getScaledSize(18),
+                        color: Colors.blue[100],
+                        height: 1.5),
+                  ),
+                  SizedBox(height: MySize.size32),
+                  Wrap(
+                    spacing: MySize.size16,
+                    runSpacing: MySize.size16,
+                    children: [
+                      ElevatedButton.icon(
+                        icon: Icon(LucideIcons.search, size: MySize.size20),
+                        label: Text("Buscar Servicio"),
+                        onPressed: () => _handleNavigation(context, 'auth_register'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.white,
+                          foregroundColor: Colors.blue[700],
+                          padding: EdgeInsets.symmetric(
+                              horizontal: MySize.size32, vertical: MySize.size16),
+                          textStyle: TextStyle(fontSize: MySize.getScaledSize(16), fontWeight: FontWeight.w600),
+                        ),
+                      ),
+                      ElevatedButton.icon(
+                        icon: Icon(LucideIcons.users, size: MySize.size20),
+                        label: Text("Ofrecer Servicio"),
+                        onPressed: () => _handleNavigation(context, 'auth_register'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.green[600],
+                          foregroundColor: Colors.white,
+                          padding: EdgeInsets.symmetric(
+                              horizontal: MySize.size32, vertical: MySize.size16),
+                          textStyle: TextStyle(fontSize: MySize.getScaledSize(16), fontWeight: FontWeight.w600),
+                        ),
+                      ),
+                    ],
+                  )
+                ],
+              ),
+            ),
+            if (isLargeScreen)
+              Expanded(
+                child: Padding(
+                  padding: EdgeInsets.only(left: MySize.size48),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(MySize.size16),
+                    child: Image.network(
+                      'https://images.pexels.com/photos/8293778/pexels-photo-8293778.jpeg?auto=compress&cs=tinysrgb&w=600&h=400&fit=crop',
+                      height: MySize.getScaledSize(300),
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        );
+      }),
+    );
+  }
+
+  Widget _buildStatsSection(BuildContext context) {
+    return Container(
+      color: Colors.grey[50],
+      padding: EdgeInsets.symmetric(vertical: MySize.size64, horizontal: MySize.size16),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          int crossAxisCount = constraints.maxWidth < 600 ? 2 : 4;
+          return GridView.builder(
+            shrinkWrap: true,
+            physics: NeverScrollableScrollPhysics(),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCount,
+              childAspectRatio: 2.0,
+              mainAxisSpacing: MySize.size32,
+              crossAxisSpacing: MySize.size32,
+            ),
+            itemCount: stats.length,
+            itemBuilder: (context, index) {
+              final stat = stats[index];
+              return Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    stat["number"],
+                    style: TextStyle(
+                        fontSize: MySize.getScaledSize(constraints.maxWidth < 600 ? 28: 36),
+                        fontWeight: FontWeight.bold,
+                        color: Colors.blue[700]),
+                  ),
+                  SizedBox(height: MySize.size4),
+                  Text(
+                    stat["label"],
+                    textAlign: TextAlign.center,
+                    style: TextStyle(fontSize: MySize.getScaledSize(14), color: Colors.grey[600]),
+                  ),
+                ],
+              );
+            },
+          );
+        }
+      ),
+    );
+  }
+
+  Widget _buildCategoriesSection(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(vertical: MySize.size64, horizontal: MySize.size16),
+      child: Column(
+        children: [
+          Text(
+            "Servicios Populares",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+                fontSize: MySize.getScaledSize(30),
+                fontWeight: FontWeight.bold,
+                color: Colors.grey[900]),
+          ),
+          SizedBox(height: MySize.size16),
+          Text(
+            "Encuentra el profesional perfecto para cualquier tarea en tu hogar o negocio",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+                fontSize: MySize.getScaledSize(18),
+                color: Colors.grey[600],
+                ),
+            maxLines: 2,
+          ),
+          SizedBox(height: MySize.size48),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              int crossAxisCount = constraints.maxWidth < 600 ? 2 : (constraints.maxWidth < 900 ? 3 : 4);
+              return GridView.builder(
+                shrinkWrap: true,
+                physics: NeverScrollableScrollPhysics(),
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: crossAxisCount,
+                  childAspectRatio: 0.9,
+                  mainAxisSpacing: MySize.size24,
+                  crossAxisSpacing: MySize.size24,
+                ),
+                itemCount: categories.length,
+                itemBuilder: (context, index) {
+                  final category = categories[index];
+                  return Card(
+                    elevation: 2.0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(MySize.size12),
+                      side: BorderSide(color: Colors.grey[100], width: 1),
+                    ),
+                    child: InkWell(
+                      onTap: () {
+                        print("Category ${category['name']} tapped");
+                      },
+                      borderRadius: BorderRadius.circular(MySize.size12),
+                      child: Padding(
+                        padding: EdgeInsets.all(MySize.size16),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Container(
+                              width: MySize.size48,
+                              height: MySize.size48,
+                              decoration: BoxDecoration(
+                                color: category["color"] as Color,
+                                borderRadius: BorderRadius.circular(MySize.size8),
+                              ),
+                              child: Icon(category["icon"] as IconData, color: category["textColor"] as Color, size: MySize.size24),
+                            ),
+                            SizedBox(height: MySize.size16),
+                            Text(
+                              category["name"] as String,
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                  fontSize: MySize.getScaledSize(16),
+                                  fontWeight: FontWeight.w600,
+                                  color: Colors.grey[900]),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              );
+            }
+          ),
+        ],
+      ),
+    );
+  }
+
+   Widget _buildFeaturesSection(BuildContext context) {
+    return Container(
+      color: Colors.grey[50],
+      padding: EdgeInsets.symmetric(vertical: MySize.size64, horizontal: MySize.size16),
+      child: Column(
+        children: [
+          Text(
+            "¿Por qué elegir ServiPerú?",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+                fontSize: MySize.getScaledSize(30),
+                fontWeight: FontWeight.bold,
+                color: Colors.grey[900]),
+          ),
+          SizedBox(height: MySize.size16),
+          Text(
+            "Ofrecemos la plataforma más confiable y segura para conectar con profesionales",
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: MySize.getScaledSize(18), color: Colors.grey[600]),
+            maxLines: 2,
+          ),
+          SizedBox(height: MySize.size48),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              bool isSmallScreen = constraints.maxWidth < 768;
+              return Flex(
+                direction: isSmallScreen ? Axis.vertical : Axis.horizontal,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: features.map((feature) {
+                  Widget card = Card(
+                    elevation: 1.0,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(MySize.size12)),
+                    child: Padding(
+                      padding: EdgeInsets.all(MySize.size32),
+                      child: Column(
+                        children: [
+                          Container(
+                            width: MySize.size64,
+                            height: MySize.size64,
+                            decoration: BoxDecoration(
+                              color: Colors.blue[100],
+                              shape: BoxShape.circle,
+                            ),
+                            child: Icon(feature["icon"] as IconData, size: MySize.size32, color: Colors.blue[700]),
+                          ),
+                          SizedBox(height: MySize.size24),
+                          Text(
+                            feature["title"] as String,
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                                fontSize: MySize.getScaledSize(20),
+                                fontWeight: FontWeight.w600,
+                                color: Colors.grey[900]),
+                          ),
+                          SizedBox(height: MySize.size16),
+                          Text(
+                            feature["description"] as String,
+                            textAlign: TextAlign.center,
+                            style: TextStyle(fontSize: MySize.getScaledSize(14), color: Colors.grey[600], height: 1.5),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                  if (isSmallScreen) {
+                    return Padding(
+                      padding: EdgeInsets.only(bottom: MySize.size32),
+                      child: card,
+                    );
+                  } else {
+                    return Expanded(child: Padding(
+                      padding: EdgeInsets.symmetric(horizontal: MySize.size16),
+                      child: card,
+                    ));
+                  }
+                }).toList(),
+              );
+            }
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCtaSection(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(vertical: MySize.size64, horizontal: MySize.size16),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [Colors.green[600], Colors.green[700]],
+          begin: Alignment.centerLeft,
+          end: Alignment.centerRight,
+        ),
+      ),
+      child: Column(
+        children: [
+          Text(
+            "¿Listo para empezar?",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+                fontSize: MySize.getScaledSize(30),
+                fontWeight: FontWeight.bold,
+                color: Colors.white),
+          ),
+          SizedBox(height: MySize.size24),
+          Text(
+            "Únete a miles de peruanos que ya confían en ServiPerú para sus necesidades de servicio",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+                fontSize: MySize.getScaledSize(18),
+                color: Colors.green[100]),
+            maxLines: 3,
+          ),
+          SizedBox(height: MySize.size32),
+          Wrap(
+            spacing: MySize.size16,
+            runSpacing: MySize.size16,
+            alignment: WrapAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: () => _handleNavigation(context, 'auth_register'),
+                child: Text("Crear Cuenta Gratis"),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.white,
+                  foregroundColor: Colors.green[700],
+                  padding: EdgeInsets.symmetric(horizontal: MySize.size32, vertical: MySize.size16),
+                  textStyle: TextStyle(fontSize: MySize.getScaledSize(16), fontWeight: FontWeight.w600),
+                ),
+              ),
+              OutlinedButton(
+                onPressed: () => _handleNavigation(context, 'auth_login'),
+                child: Text("Iniciar Sesión"),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: Colors.white,
+                  side: BorderSide(color: Colors.white, width: 2),
+                  padding: EdgeInsets.symmetric(horizontal: MySize.size32, vertical: MySize.size16),
+                  textStyle: TextStyle(fontSize: MySize.getScaledSize(16), fontWeight: FontWeight.w600),
+                ),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}
+// Note: The build<SectionName> methods are identical to the previous version and are included for completeness
+// of the file recreation. The main changes are the import of RecreatedClientDashboardPage
+// and the updated _handleNavigation method.
+// Also, a boolean `isDemoAuthenticated` is added to easily toggle header state for testing navigation.

--- a/flutter-ui-boilerplate/lib/widgets/recreated_header.dart
+++ b/flutter-ui-boilerplate/lib/widgets/recreated_header.dart
@@ -1,0 +1,302 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_flutter/lucide_flutter.dart';
+import 'package:boilerplate_ui/utils/size_config.dart'; // Assuming MySize is used for responsive sizing
+
+class RecreatedHeader extends StatelessWidget implements PreferredSizeWidget {
+  final bool isAuthenticated;
+  final String currentPage; // To highlight the current page
+  final Function(String) onNavigate; // Callback for navigation
+  // final Function onLogout; // Will be used later
+  // final dynamic currentUser; // Will be used later
+
+  const RecreatedHeader({
+    Key key,
+    this.isAuthenticated = false,
+    this.currentPage = 'home',
+    this.onNavigate,
+    // this.onLogout,
+    // this.currentUser,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    MySize().init(context); // Initialize MySize for responsive text/padding
+
+    return AppBar(
+      backgroundColor: Colors.white,
+      elevation: 1.0, // shadow-sm equivalent
+      automaticallyImplyLeading: false, // Removes back button if this is the first screen
+      titleSpacing: 0,
+      title: Padding(
+        padding: EdgeInsets.symmetric(horizontal: MySize.size16), // Equivalent to px-4 (sm:px-6 lg:px-8 can be handled with MySize or MediaQuery)
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            // Logo
+            GestureDetector(
+              onTap: () {
+                onNavigate?.call('home');
+              },
+              child: Row(
+                children: [
+                  Container(
+                    padding: EdgeInsets.all(MySize.size8), // p-2
+                    decoration: BoxDecoration(
+                      color: Colors.blue[700], // bg-blue-700
+                      borderRadius: BorderRadius.circular(MySize.size8), // rounded-lg
+                    ),
+                    child: Icon(LucideIcons.user, color: Colors.white, size: MySize.size24), // h-6 w-6
+                  ),
+                  SizedBox(width: MySize.size12), // mr-3
+                  Text(
+                    "ServiPerú",
+                    style: TextStyle(
+                      fontSize: MySize.getScaledSize(20), // text-xl
+                      fontWeight: FontWeight.bold,
+                      color: Colors.grey[900], // text-gray-900
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Desktop Navigation (Simplified for now)
+            if (MySize.screenWidth > 768) // md breakpoint
+              _buildDesktopNavigation(context),
+
+            // Mobile menu button (Placeholder for now)
+            if (MySize.screenWidth <= 768)
+              IconButton(
+                icon: Icon(LucideIcons.menu, color: Colors.grey[600]),
+                onPressed: () {
+                  // Handle mobile menu toggle
+                  print("Mobile menu tapped");
+                  Scaffold.of(context).openEndDrawer(); // Example: open a drawer
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDesktopNavigation(BuildContext context) {
+    if (!isAuthenticated) {
+      return Row(
+        children: [
+          _navButton(context, "Inicio", "home", currentPage == 'home', onNavigate),
+          SizedBox(width: MySize.size32), // space-x-8
+          _actionButton(
+            context,
+            "Buscar Servicio",
+            () { onNavigate?.call('auth_register'); },
+            Colors.blue[700], // bg-blue-700
+            Colors.blue[800], // hover:bg-blue-800
+          ),
+          SizedBox(width: MySize.size16),
+          _actionButton(
+            context,
+            "Ofrecer Servicio",
+            () { onNavigate?.call('auth_register'); },
+            Colors.green[600], // bg-green-600
+            Colors.green[700], // hover:bg-green-700
+          ),
+        ],
+      );
+    } else {
+      // Authenticated state navigation
+      return Row(
+        children: [
+          // Updated "dashboard" to "client_dashboard" for specific navigation
+          _navButton(context, "Panel Principal", "client_dashboard", currentPage.contains('dashboard'), onNavigate),
+          SizedBox(width: MySize.size32),
+          _navButton(context, "Suscripciones", "subscriptions_page", currentPage == 'subscriptions', onNavigate),
+          SizedBox(width: MySize.size24),
+          Row(
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    "User Name", // currentUser.name Placeholder
+                    style: TextStyle(fontSize: MySize.getScaledSize(14), fontWeight: FontWeight.w500, color: Colors.grey[900]),
+                  ),
+                  Text(
+                    "Client", // currentUser.type Placeholder (capitalized)
+                    style: TextStyle(fontSize: MySize.getScaledSize(12), color: Colors.grey[500]),
+                  ),
+                ],
+              ),
+              SizedBox(width: MySize.size12),
+              TextButton(
+                onPressed: () { onNavigate?.call('logout'); }, // Changed to use onNavigate
+                child: Text(
+                  "Cerrar Sesión",
+                  style: TextStyle(color: Colors.grey[400], fontSize: MySize.getScaledSize(14)),
+                ),
+                style: TextButton.styleFrom(
+                  padding: EdgeInsets.zero,
+                  minimumSize: Size(MySize.size50, MySize.size30),
+                ),
+              ),
+            ],
+          )
+        ],
+      );
+    }
+  }
+
+  Widget _navButton(BuildContext context, String text, String pageKey, bool isActive, Function(String) navCallback) {
+    return TextButton(
+      onPressed: () {
+        navCallback?.call(pageKey);
+      },
+      style: TextButton.styleFrom(
+        foregroundColor: isActive ? Colors.blue[700] : Colors.grey[700],
+        padding: EdgeInsets.symmetric(vertical: MySize.size8, horizontal: MySize.size4),
+        textStyle: TextStyle(
+          fontWeight: FontWeight.w500,
+          fontSize: MySize.getScaledSize(14),
+        ),
+      ),
+      child: Text(text),
+    );
+  }
+
+  Widget _actionButton(BuildContext context, String text, VoidCallback onPressed, Color bgColor, Color hoverBgColor) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: bgColor,
+        padding: EdgeInsets.symmetric(horizontal: MySize.size16, vertical: MySize.size10),
+        textStyle: TextStyle(
+          fontSize: MySize.getScaledSize(14),
+          fontWeight: FontWeight.w500,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(MySize.size8),
+        ),
+        elevation: 0,
+      ).copyWith(
+        overlayColor: MaterialStateProperty.resolveWith<Color>(
+          (Set<MaterialState> states) {
+            if (states.contains(MaterialState.hovered)) return hoverBgColor;
+            return null;
+          },
+        ),
+      ),
+      child: Text(text, style: TextStyle(color: Colors.white)),
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(MySize.size64);
+}
+
+class RecreatedMobileDrawer extends StatelessWidget {
+  final Function(String) onNavigate;
+  const RecreatedMobileDrawer({Key key, this.onNavigate}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: <Widget>[
+          DrawerHeader(
+            decoration: BoxDecoration(
+              color: Colors.blue[700],
+            ),
+            child: Text(
+              'ServiPerú Menú',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: MySize.getScaledSize(24),
+              ),
+            ),
+          ),
+          ListTile(
+            leading: Icon(LucideIcons.home),
+            title: Text('Inicio'),
+            onTap: () {
+              Navigator.pop(context);
+              onNavigate?.call('home');
+            },
+          ),
+          ListTile(
+            leading: Icon(LucideIcons.search), // Or UserPlus for register
+            title: Text('Buscar/Ofrecer Servicio (Registrarse)'),
+            onTap: () {
+              Navigator.pop(context);
+              onNavigate?.call('auth_register');
+            },
+          ),
+          ListTile(
+            leading: Icon(LucideIcons.logIn),
+            title: Text('Iniciar Sesión'),
+            onTap: () {
+              Navigator.pop(context);
+              onNavigate?.call('auth_login');
+            },
+          ),
+          // Added items for authenticated state to mobile drawer
+          if(onNavigate != null) ...[ // A bit of a hack to check if it's in an authenticated context
+            Divider(),
+            ListTile(
+              leading: Icon(LucideIcons.layoutDashboard),
+              title: Text('Panel Cliente'), // Renamed for clarity
+              onTap: () {
+                Navigator.pop(context);
+                onNavigate('client_dashboard');
+              },
+            ),
+            ListTile( // Added Worker Dashboard Navigation
+              leading: Icon(LucideIcons.hardHat), // Icon for worker
+              title: Text('Panel Trabajador'),
+              onTap: () {
+                Navigator.pop(context);
+                onNavigate('worker_dashboard');
+              },
+            ),
+            ListTile(
+              leading: Icon(LucideIcons.gem), // Gem or CreditCard for subscriptions
+              title: Text('Suscripciones'),
+              onTap: () {
+                Navigator.pop(context);
+                onNavigate('subscriptions_page');
+              },
+            ),
+            ListTile(
+              leading: Icon(LucideIcons.logOut),
+              title: Text('Cerrar Sesión'),
+              onTap: () {
+                Navigator.pop(context);
+                onNavigate('logout'); // Special key for logout
+              },
+            ),
+          ]
+        ],
+      ),
+    );
+  }
+}
+
+// Updated notes:
+// - Added `Function(String) onNavigate` to RecreatedHeader constructor.
+// - `onNavigate` is called in `GestureDetector` for logo, `_navButton`, and `_actionButton`.
+// - Changed navigation keys for "Buscar Servicio" and "Ofrecer Servicio" to 'auth_register'.
+// - For authenticated state, "Panel Principal" now navigates to 'client_dashboard'.
+// - "Suscripciones" now navigates to 'subscriptions_page'.
+// - Added `onNavigate` to `RecreatedMobileDrawer` and wired up its ListTiles.
+// - Added "Iniciar Sesión", "Panel Principal", "Suscripciones", "Cerrar Sesión" to mobile drawer,
+//   conditionally showing auth items if onNavigate is available (as a proxy for being in an auth context,
+//   ideally this would be driven by an `isAuthenticated` flag).
+// - The `print` statements in navigation callbacks are kept for debugging but `onNavigate` is now the primary mechanism.
+// - Assumed `MySize().init(context)` is called in parent screens.
+// - The `isAuthenticated`, `currentUser`, `onLogout` logic is still placeholder in RecreatedHeader itself,
+//   but the drawer now has more items.
+// - `currentPage` is used for highlighting active nav button.
+// - `Scaffold.of(context).openEndDrawer()` is called for mobile menu button.
+//   The parent Scaffold needs to have `endDrawer: RecreatedMobileDrawer(onNavigate: _handleNavigation),`
+//   where `_handleNavigation` is a method in the parent widget (e.g. RecreatedHomePage or a new main app shell).

--- a/flutter-ui-boilerplate/pubspec.yaml
+++ b/flutter-ui-boilerplate/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   provider: ^6.0.4
   shared_preferences: ^2.0.15
   material_design_icons_flutter: ^5.0.6996
+  lucide_flutter: ^0.303.0 # Added lucide_flutter for icons
   google_fonts: ^3.0.1
   flutter_html: ^2.2.1
   url_launcher: ^6.1.6


### PR DESCRIPTION
Replicates the main visual structure of components from the 'project/' directory (Header, HomePage, AuthPage, ClientDashboard, WorkerDashboard, SubscriptionsPage) as new Flutter widgets within the 'flutter-ui-boilerplate' application.

- Creates new Dart files under `lib/views/recreated/` for each page and `lib/widgets/` for the shared header.
- Implements basic UI structure and layout based on Tailwind CSS classes found in the original TSX components.
- Uses mock data for content display.
- Adds `lucide_flutter` dependency for icons.
- Sets up basic navigation between these recreated pages.
- Updates `main.dart` to launch the new `RecreatedHomePage`.

This commit focuses on the UI skeleton and visual representation. Further work will be needed for full functionality, state management, and business logic.